### PR TITLE
feat: P1-008 ECS Component基盤実装 ⭐️

### DIFF
--- a/src/infrastructure/ecs/Component.ts
+++ b/src/infrastructure/ecs/Component.ts
@@ -1,0 +1,36 @@
+/**
+ * ECS Component基盤 - 基本コンポーネント定義
+ *
+ * Entity-Component-Systemアーキテクチャの基本コンポーネントを提供
+ * Schema.Structを使用した型安全でシリアライズ可能な実装
+ */
+
+import { Schema } from 'effect'
+
+/**
+ * 位置コンポーネント - 3D空間内の座標
+ */
+export const PositionComponent = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+  z: Schema.Number,
+})
+
+/**
+ * 速度コンポーネント - 3D空間内の移動速度
+ */
+export const VelocityComponent = Schema.Struct({
+  vx: Schema.Number,
+  vy: Schema.Number,
+  vz: Schema.Number,
+})
+
+/**
+ * 位置コンポーネントの型定義
+ */
+export type PositionComponent = Schema.Schema.Type<typeof PositionComponent>
+
+/**
+ * 速度コンポーネントの型定義
+ */
+export type VelocityComponent = Schema.Schema.Type<typeof VelocityComponent>

--- a/src/infrastructure/ecs/ComponentRegistry.ts
+++ b/src/infrastructure/ecs/ComponentRegistry.ts
@@ -1,0 +1,32 @@
+/**
+ * ECS Component Registry - コンポーネント管理システム
+ *
+ * 全コンポーネントの登録・管理・型安全性確保を担当
+ * シリアライズ・デシリアライズ機能付き
+ */
+
+import { Schema } from 'effect'
+import { PositionComponent, VelocityComponent } from './Component'
+
+/**
+ * 登録済みコンポーネント一覧
+ */
+export const ComponentRegistry = Schema.Struct({
+  position: Schema.optional(PositionComponent),
+  velocity: Schema.optional(VelocityComponent),
+})
+
+/**
+ * コンポーネントレジストリの型定義
+ */
+export type ComponentRegistry = Schema.Schema.Type<typeof ComponentRegistry>
+
+/**
+ * 個別コンポーネント型のUnion定義
+ */
+export const ComponentUnion = Schema.Union(PositionComponent, VelocityComponent)
+
+/**
+ * コンポーネントUnionの型定義
+ */
+export type ComponentUnion = Schema.Schema.Type<typeof ComponentUnion>

--- a/src/infrastructure/ecs/__test__/Component.spec.ts
+++ b/src/infrastructure/ecs/__test__/Component.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * ECS Component テスト
+ *
+ * Schema.Struct定義、型安全性、シリアライズ可能性の検証
+ */
+
+import { describe, it, expect } from 'vitest'
+import { Schema } from 'effect'
+import { PositionComponent, VelocityComponent } from '../Component'
+
+describe('ECS Components', () => {
+  describe('PositionComponent', () => {
+    it('should create valid position component', () => {
+      const position = { x: 10, y: 20, z: 30 }
+      const result = Schema.decodeUnknownSync(PositionComponent)(position)
+
+      expect(result).toEqual(position)
+      expect(result.x).toBe(10)
+      expect(result.y).toBe(20)
+      expect(result.z).toBe(30)
+    })
+
+    it('should be serializable to JSON', () => {
+      const position = { x: 1.5, y: -2.3, z: 4.7 }
+      const decoded = Schema.decodeUnknownSync(PositionComponent)(position)
+      const json = JSON.stringify(decoded)
+      const parsed = JSON.parse(json)
+
+      expect(parsed).toEqual(position)
+    })
+
+    it('should validate numeric values', () => {
+      expect(() => {
+        Schema.decodeUnknownSync(PositionComponent)({ x: 'invalid', y: 20, z: 30 })
+      }).toThrow()
+    })
+
+    it('should require all coordinates', () => {
+      expect(() => {
+        Schema.decodeUnknownSync(PositionComponent)({ x: 10, y: 20 })
+      }).toThrow()
+    })
+  })
+
+  describe('VelocityComponent', () => {
+    it('should create valid velocity component', () => {
+      const velocity = { vx: 1.5, vy: -0.5, vz: 2.0 }
+      const result = Schema.decodeUnknownSync(VelocityComponent)(velocity)
+
+      expect(result).toEqual(velocity)
+      expect(result.vx).toBe(1.5)
+      expect(result.vy).toBe(-0.5)
+      expect(result.vz).toBe(2.0)
+    })
+
+    it('should be serializable to JSON', () => {
+      const velocity = { vx: 0.1, vy: 0.2, vz: 0.3 }
+      const decoded = Schema.decodeUnknownSync(VelocityComponent)(velocity)
+      const json = JSON.stringify(decoded)
+      const parsed = JSON.parse(json)
+
+      expect(parsed).toEqual(velocity)
+    })
+
+    it('should validate numeric values', () => {
+      expect(() => {
+        Schema.decodeUnknownSync(VelocityComponent)({ vx: 1, vy: 'invalid', vz: 3 })
+      }).toThrow()
+    })
+
+    it('should require all velocity components', () => {
+      expect(() => {
+        Schema.decodeUnknownSync(VelocityComponent)({ vx: 1, vy: 2 })
+      }).toThrow()
+    })
+  })
+})

--- a/src/infrastructure/ecs/__test__/ComponentRegistry.spec.ts
+++ b/src/infrastructure/ecs/__test__/ComponentRegistry.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * ECS Component Registry テスト
+ *
+ * コンポーネント管理システムの型安全性とシリアライズ対応を検証
+ */
+
+import { describe, it, expect } from 'vitest'
+import { Schema } from 'effect'
+import { ComponentRegistry, ComponentUnion } from '../ComponentRegistry'
+
+describe('ECS Component Registry', () => {
+  describe('ComponentRegistry', () => {
+    it('should create empty registry', () => {
+      const registry = {}
+      const result = Schema.decodeUnknownSync(ComponentRegistry)(registry)
+
+      expect(result).toEqual({})
+    })
+
+    it('should create registry with position component', () => {
+      const registry = {
+        position: { x: 10, y: 20, z: 30 },
+      }
+      const result = Schema.decodeUnknownSync(ComponentRegistry)(registry)
+
+      expect(result.position).toEqual({ x: 10, y: 20, z: 30 })
+      expect(result.velocity).toBeUndefined()
+    })
+
+    it('should create registry with velocity component', () => {
+      const registry = {
+        velocity: { vx: 1.5, vy: -0.5, vz: 2.0 },
+      }
+      const result = Schema.decodeUnknownSync(ComponentRegistry)(registry)
+
+      expect(result.velocity).toEqual({ vx: 1.5, vy: -0.5, vz: 2.0 })
+      expect(result.position).toBeUndefined()
+    })
+
+    it('should create registry with both components', () => {
+      const registry = {
+        position: { x: 10, y: 20, z: 30 },
+        velocity: { vx: 1.5, vy: -0.5, vz: 2.0 },
+      }
+      const result = Schema.decodeUnknownSync(ComponentRegistry)(registry)
+
+      expect(result.position).toEqual({ x: 10, y: 20, z: 30 })
+      expect(result.velocity).toEqual({ vx: 1.5, vy: -0.5, vz: 2.0 })
+    })
+
+    it('should be serializable to JSON', () => {
+      const registry = {
+        position: { x: 1.1, y: 2.2, z: 3.3 },
+        velocity: { vx: 0.1, vy: 0.2, vz: 0.3 },
+      }
+      const decoded = Schema.decodeUnknownSync(ComponentRegistry)(registry)
+      const json = JSON.stringify(decoded)
+      const parsed = JSON.parse(json)
+
+      expect(parsed).toEqual(registry)
+    })
+  })
+
+  describe('ComponentUnion', () => {
+    it('should decode position component', () => {
+      const position = { x: 10, y: 20, z: 30 }
+      const result = Schema.decodeUnknownSync(ComponentUnion)(position)
+
+      expect(result).toEqual(position)
+    })
+
+    it('should decode velocity component', () => {
+      const velocity = { vx: 1.5, vy: -0.5, vz: 2.0 }
+      const result = Schema.decodeUnknownSync(ComponentUnion)(velocity)
+
+      expect(result).toEqual(velocity)
+    })
+
+    it('should reject invalid component', () => {
+      expect(() => {
+        Schema.decodeUnknownSync(ComponentUnion)({ invalid: 'data' })
+      }).toThrow()
+    })
+  })
+})

--- a/src/infrastructure/ecs/index.ts
+++ b/src/infrastructure/ecs/index.ts
@@ -1,0 +1,9 @@
+/**
+ * ECS Infrastructure Module
+ *
+ * Entity-Component-Systemアーキテクチャの基盤実装
+ * 型安全でシリアライズ可能なコンポーネントシステムを提供
+ */
+
+export * from './Component'
+export * from './ComponentRegistry'

--- a/src/infrastructure/index.ts
+++ b/src/infrastructure/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './rendering'
+export * from './ecs'


### PR DESCRIPTION
## 📋 概要
Issue #131「P1-008: ECS Component基盤」の実装

Entity-Component-Systemアーキテクチャの基本コンポーネント基盤を実装しました。

## 🚀 実装内容

### コンポーネント定義
- **PositionComponent**: 3D空間内の座標 (x, y, z)
- **VelocityComponent**: 3D空間内の移動速度 (vx, vy, vz)

### コンポーネント管理
- **ComponentRegistry**: オプショナルフィールドによるコンポーネント管理
- **ComponentUnion**: 型安全なコンポーネントUnion定義

## ✅ 成功基準達成

- [x] Schema.Struct定義
- [x] 型安全性（TypeScript + Effect-TS Schema）
- [x] シリアライズ可能（JSON互換）

## 🛠 技術仕様

```typescript
// 基本コンポーネント定義
export const PositionComponent = Schema.Struct({
  x: Schema.Number,
  y: Schema.Number,
  z: Schema.Number
})

// コンポーネント管理システム
export const ComponentRegistry = Schema.Struct({
  position: Schema.optional(PositionComponent),
  velocity: Schema.optional(VelocityComponent)
})
```

## 🧪 テスト戦略

- Schema.decodeUnknownSync()によるバリデーション検証
- JSON互換シリアライズ/デシリアライズテスト
- 不正値でのエラーハンドリング検証
- 必須フィールドの検証

## 📁 ファイル構成

```
src/infrastructure/ecs/
├── Component.ts           # 基本コンポーネント定義
├── ComponentRegistry.ts   # コンポーネント管理システム  
├── index.ts              # モジュールエクスポート
└── __test__/
    ├── Component.spec.ts
    └── ComponentRegistry.spec.ts
```

## 🔍 CI結果

- ✅ TypeScript型チェック: PASS
- ✅ Prettierフォーマット: PASS  
- ✅ EditorConfig: PASS
- ✅ テストスイート: 514/514 PASS
- ✅ 新規テスト: 16/16 PASS

## 🎯 依存関係

- P0-002 (#111) の依存を満たしています

Closes #131