### PR TITLE
feat: 入力システムインターフェース定義 (#136)

### DIFF
--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -8,3 +8,6 @@
 
 // Scene Management Domain
 export * from './scene'
+
+// Input System Domain
+export * from './input'

--- a/src/domain/input/InputService.ts
+++ b/src/domain/input/InputService.ts
@@ -1,0 +1,16 @@
+import { Effect, Context } from 'effect'
+import type { InputHandler, MouseDelta, InputState, InputError } from './types'
+
+// InputServiceインターフェース定義
+export interface InputService {
+  readonly isKeyPressed: (key: string) => Effect.Effect<boolean, never>
+  readonly isMousePressed: (button: number) => Effect.Effect<boolean, never>
+  readonly getMouseDelta: () => Effect.Effect<MouseDelta, never>
+  readonly registerHandler: (handler: InputHandler) => Effect.Effect<void, never>
+  readonly unregisterHandler: (id: string) => Effect.Effect<void, InputError>
+  readonly getState: () => Effect.Effect<InputState, never>
+  readonly reset: () => Effect.Effect<void, never>
+}
+
+// InputServiceタグ定義
+export const InputService = Context.GenericTag<InputService>('@services/InputService')

--- a/src/domain/input/__test__/InputService.spec.ts
+++ b/src/domain/input/__test__/InputService.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { Effect, Context } from 'effect'
+import { InputService } from '../InputService'
+import type { InputHandler, MouseDelta, InputState } from '../types'
+
+describe('InputService', () => {
+  // モックサービス実装
+  const mockInputService: InputService = {
+    isKeyPressed: (key: string) => Effect.succeed(key === 'a'),
+    isMousePressed: (button: number) => Effect.succeed(button === 0),
+    getMouseDelta: () => Effect.succeed({ x: 10, y: 5 } as MouseDelta),
+    registerHandler: () => Effect.succeed(void 0),
+    unregisterHandler: () => Effect.succeed(void 0),
+    getState: () =>
+      Effect.succeed({
+        keys: { a: true },
+        mouseButtons: { '0': true },
+        mouseDelta: { x: 10, y: 5 },
+      } as InputState),
+    reset: () => Effect.succeed(void 0),
+  }
+
+  describe('インターフェース定義', () => {
+    it('InputServiceタグが正しく定義されている', () => {
+      expect(InputService).toBeDefined()
+      expect(InputService.key).toBe('@services/InputService')
+    })
+
+    it('必要なメソッドがすべて定義されている', () => {
+      expect(mockInputService.isKeyPressed).toBeDefined()
+      expect(mockInputService.isMousePressed).toBeDefined()
+      expect(mockInputService.getMouseDelta).toBeDefined()
+      expect(mockInputService.registerHandler).toBeDefined()
+      expect(mockInputService.unregisterHandler).toBeDefined()
+      expect(mockInputService.getState).toBeDefined()
+      expect(mockInputService.reset).toBeDefined()
+    })
+  })
+
+  describe('サービス利用', () => {
+    it('Contextを通じてサービスを利用できる', async () => {
+      const program = Effect.gen(function* () {
+        const input = yield* InputService
+        const isPressed = yield* input.isKeyPressed('a')
+        return isPressed
+      })
+
+      const result = await Effect.runPromise(program.pipe(Effect.provideService(InputService, mockInputService)))
+
+      expect(result).toBe(true)
+    })
+
+    it('複数のメソッドを組み合わせて利用できる', async () => {
+      const program = Effect.gen(function* () {
+        const input = yield* InputService
+        const keyPressed = yield* input.isKeyPressed('a')
+        const mousePressed = yield* input.isMousePressed(0)
+        const delta = yield* input.getMouseDelta()
+        return { keyPressed, mousePressed, delta }
+      })
+
+      const result = await Effect.runPromise(program.pipe(Effect.provideService(InputService, mockInputService)))
+
+      expect(result).toEqual({
+        keyPressed: true,
+        mousePressed: true,
+        delta: { x: 10, y: 5 },
+      })
+    })
+
+    it('状態を取得できる', async () => {
+      const program = Effect.gen(function* () {
+        const input = yield* InputService
+        return yield* input.getState()
+      })
+
+      const result = await Effect.runPromise(program.pipe(Effect.provideService(InputService, mockInputService)))
+
+      expect(result).toEqual({
+        keys: { a: true },
+        mouseButtons: { '0': true },
+        mouseDelta: { x: 10, y: 5 },
+      })
+    })
+
+    it('ハンドラーを登録できる', async () => {
+      const program = Effect.gen(function* () {
+        const input = yield* InputService
+        const handler: InputHandler = {
+          id: 'test',
+          priority: 10,
+          handle: () => Effect.succeed(void 0),
+        }
+        yield* input.registerHandler(handler)
+        return true
+      })
+
+      const result = await Effect.runPromise(program.pipe(Effect.provideService(InputService, mockInputService)))
+
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/src/domain/input/__test__/types.spec.ts
+++ b/src/domain/input/__test__/types.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@effect/schema'
+import {
+  MouseButton,
+  MouseDelta,
+  InputState,
+  InputEventType,
+  InputEvent,
+  InputHandler,
+  InputError,
+  MOUSE_BUTTON,
+} from '../types'
+
+describe('Input Types', () => {
+  describe('MouseButton', () => {
+    it('有効なマウスボタン値を受け入れる', () => {
+      const validButtons = [0, 1, 2]
+      validButtons.forEach((button) => {
+        expect(() => Schema.decodeUnknownSync(MouseButton)(button)).not.toThrow()
+      })
+    })
+
+    it('無効なマウスボタン値を拒否する', () => {
+      const invalidButtons = [-1, 3, 4, 'left', null, undefined]
+      invalidButtons.forEach((button) => {
+        expect(() => Schema.decodeUnknownSync(MouseButton)(button)).toThrow()
+      })
+    })
+
+    it('定数が正しく定義されている', () => {
+      expect(MOUSE_BUTTON.LEFT).toBe(0)
+      expect(MOUSE_BUTTON.MIDDLE).toBe(1)
+      expect(MOUSE_BUTTON.RIGHT).toBe(2)
+    })
+  })
+
+  describe('MouseDelta', () => {
+    it('有効なマウスデルタを受け入れる', () => {
+      const delta = { x: 10, y: -5 }
+      const decoded = Schema.decodeUnknownSync(MouseDelta)(delta)
+      expect(decoded).toEqual(delta)
+    })
+
+    it('必須フィールドがない場合エラーを発生させる', () => {
+      expect(() => Schema.decodeUnknownSync(MouseDelta)({ x: 10 })).toThrow()
+      expect(() => Schema.decodeUnknownSync(MouseDelta)({ y: 5 })).toThrow()
+      expect(() => Schema.decodeUnknownSync(MouseDelta)({})).toThrow()
+    })
+
+    it('シリアライズ可能である', () => {
+      const delta = { x: 100, y: -50 }
+      const decoded = Schema.decodeUnknownSync(MouseDelta)(delta)
+      const serialized = JSON.stringify(decoded)
+      const deserialized = JSON.parse(serialized)
+      expect(Schema.decodeUnknownSync(MouseDelta)(deserialized)).toEqual(delta)
+    })
+  })
+
+  describe('InputState', () => {
+    it('有効な入力状態を受け入れる', () => {
+      const state = {
+        keys: { a: true, b: false },
+        mouseButtons: { '0': true, '1': false },
+        mouseDelta: { x: 0, y: 0 },
+      }
+      const decoded = Schema.decodeUnknownSync(InputState)(state)
+      expect(decoded).toEqual(state)
+    })
+
+    it('空の状態を受け入れる', () => {
+      const emptyState = {
+        keys: {},
+        mouseButtons: {},
+        mouseDelta: { x: 0, y: 0 },
+      }
+      const decoded = Schema.decodeUnknownSync(InputState)(emptyState)
+      expect(decoded).toEqual(emptyState)
+    })
+
+    it('必須フィールドがない場合エラーを発生させる', () => {
+      expect(() =>
+        Schema.decodeUnknownSync(InputState)({
+          keys: {},
+          mouseButtons: {},
+        })
+      ).toThrow()
+    })
+  })
+
+  describe('InputEventType', () => {
+    it('有効なイベントタイプを受け入れる', () => {
+      const validTypes = ['keydown', 'keyup', 'mousedown', 'mouseup', 'mousemove']
+      validTypes.forEach((type) => {
+        expect(() => Schema.decodeUnknownSync(InputEventType)(type)).not.toThrow()
+      })
+    })
+
+    it('無効なイベントタイプを拒否する', () => {
+      const invalidTypes = ['click', 'touch', 'scroll', 123, null]
+      invalidTypes.forEach((type) => {
+        expect(() => Schema.decodeUnknownSync(InputEventType)(type)).toThrow()
+      })
+    })
+  })
+
+  describe('InputEvent', () => {
+    it('キーイベントを受け入れる', () => {
+      const keyEvent = {
+        type: 'keydown',
+        key: 'a',
+        timestamp: Date.now(),
+      }
+      const decoded = Schema.decodeUnknownSync(InputEvent)(keyEvent)
+      expect(decoded).toEqual(keyEvent)
+    })
+
+    it('マウスボタンイベントを受け入れる', () => {
+      const mouseEvent = {
+        type: 'mousedown',
+        button: 0,
+        timestamp: Date.now(),
+      }
+      const decoded = Schema.decodeUnknownSync(InputEvent)(mouseEvent)
+      expect(decoded).toEqual(mouseEvent)
+    })
+
+    it('マウス移動イベントを受け入れる', () => {
+      const mouseMoveEvent = {
+        type: 'mousemove',
+        delta: { x: 10, y: 5 },
+        timestamp: Date.now(),
+      }
+      const decoded = Schema.decodeUnknownSync(InputEvent)(mouseMoveEvent)
+      expect(decoded).toEqual(mouseMoveEvent)
+    })
+
+    it('必須フィールドがない場合エラーを発生させる', () => {
+      expect(() =>
+        Schema.decodeUnknownSync(InputEvent)({
+          type: 'keydown',
+        })
+      ).toThrow()
+    })
+  })
+
+  describe('InputHandler', () => {
+    it('有効なハンドラーを受け入れる', () => {
+      const handler = {
+        id: 'test-handler',
+        priority: 10,
+        handle: () => {},
+      }
+      const decoded = Schema.decodeUnknownSync(InputHandler)(handler)
+      expect(decoded.id).toBe(handler.id)
+      expect(decoded.priority).toBe(handler.priority)
+    })
+
+    it('必須フィールドがない場合エラーを発生させる', () => {
+      expect(() =>
+        Schema.decodeUnknownSync(InputHandler)({
+          id: 'test',
+          // priorityがない
+        })
+      ).toThrow()
+    })
+  })
+
+  describe('InputError', () => {
+    it('エラーインスタンスを作成できる', () => {
+      const error = new InputError({ reason: 'Test error' })
+      expect(error).toBeInstanceOf(InputError)
+      expect(error.reason).toBe('Test error')
+    })
+
+    it('エラーメッセージを持つ', () => {
+      const error = new InputError({ reason: 'Handler not found' })
+      expect(error.message).toBeDefined()
+      expect(error.reason).toBe('Handler not found')
+    })
+  })
+})

--- a/src/domain/input/index.ts
+++ b/src/domain/input/index.ts
@@ -1,0 +1,5 @@
+// 型定義のエクスポート
+export * from './types'
+
+// サービスインターフェースのエクスポート
+export { InputService } from './InputService'

--- a/src/domain/input/types.ts
+++ b/src/domain/input/types.ts
@@ -1,0 +1,54 @@
+import { Schema } from '@effect/schema'
+
+// マウスボタン定義
+export const MouseButton = Schema.Literal(0, 1, 2)
+export type MouseButton = Schema.Schema.Type<typeof MouseButton>
+
+// マウスボタンの定数
+export const MOUSE_BUTTON = {
+  LEFT: 0,
+  MIDDLE: 1,
+  RIGHT: 2,
+} as const
+
+// マウスデルタ（移動量）
+export const MouseDelta = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+})
+export type MouseDelta = Schema.Schema.Type<typeof MouseDelta>
+
+// 入力状態
+export const InputState = Schema.Struct({
+  keys: Schema.Record({ key: Schema.String, value: Schema.Boolean }),
+  mouseButtons: Schema.Record({ key: Schema.String, value: Schema.Boolean }),
+  mouseDelta: MouseDelta,
+})
+export type InputState = Schema.Schema.Type<typeof InputState>
+
+// 入力イベントタイプ
+export const InputEventType = Schema.Literal('keydown', 'keyup', 'mousedown', 'mouseup', 'mousemove')
+export type InputEventType = Schema.Schema.Type<typeof InputEventType>
+
+// 基本入力イベント
+export const InputEvent = Schema.Struct({
+  type: InputEventType,
+  key: Schema.optional(Schema.String),
+  button: Schema.optional(MouseButton),
+  delta: Schema.optional(MouseDelta),
+  timestamp: Schema.Number,
+})
+export type InputEvent = Schema.Schema.Type<typeof InputEvent>
+
+// 入力ハンドラー型
+export const InputHandler = Schema.Struct({
+  id: Schema.String,
+  priority: Schema.Number,
+  handle: Schema.Any, // Effect関数は直接スキーマ化できないため
+})
+export type InputHandler = Schema.Schema.Type<typeof InputHandler>
+
+// エラー定義
+export class InputError extends Schema.TaggedError<InputError>()('InputError', {
+  reason: Schema.String,
+}) {}


### PR DESCRIPTION
## 概要
Issue #136 「P1-011: Input Interface」の実装

## 変更内容
### 実装ファイル
- `src/domain/input/types.ts` - 入力関連の型定義
- `src/domain/input/InputService.ts` - InputServiceインターフェース
- `src/domain/input/__test__/*.spec.ts` - テストファイル

### 実装内容
- ✅ 入力インターフェース定義
  - `isKeyPressed`, `isMousePressed`, `getMouseDelta`メソッド
  - `registerHandler`, `unregisterHandler`によるハンドラー管理
  - `getState`, `reset`による状態管理
- ✅ Effect統合
  - 全メソッドがEffect.Effectを返す型安全な実装
  - Context.GenericTagによるDI対応
- ✅ 型安全性
  - Schema.Structによる厳密な型定義
  - MouseButton, InputEvent等の値オブジェクト定義

## テスト
- `pnpm test src/domain/input` ✅ 全テスト合格
- `pnpm typecheck` ✅ 型チェック通過
- `pnpm build` ✅ ビルド成功

## 関連Issue
- Closes #136